### PR TITLE
add QuantumInformation.jl

### DIFF
--- a/qosf.org/_data/yaml_project_list.yml
+++ b/qosf.org/_data/yaml_project_list.yml
@@ -106,6 +106,9 @@
   - description: Julia library for quantum information related calculations.
     name: QuantumInfo.jl
     url: https://github.com/BBN-Q/QuantumInfo.jl
+  - description: A Julia package for numerical computation in quantum information theory.
+    name: QuantumInformation.jl
+    url: https://github.com/ZKSI/QuantumInformation.jl
   - description: Tools for quantum control, simulation, channel representation conversion,
       and perturbations.
     name: QuantumUtils


### PR DESCRIPTION
There isn't somewhere on the project list to link to relevant overview papers, which is probably fine. If there is a place on the site for it, then the quantuminformation.jl paper is here: https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0209358