### PR TITLE
Fix typo under memberships

### DIFF
--- a/qosf.org/manifesto.md
+++ b/qosf.org/manifesto.md
@@ -36,7 +36,7 @@ The Quantum Open Source Foundation, herein after referred to as QOSF, is charged
 
 # Membership
 
-Membership in the QOSF is open and free to anyone interested in open source software development for quantum computing. Members and supporters of the QOSF are not obliged to donate to the foundation itself but are committing to support the values stated in this manifesto. There are no dues of any kind. You can become a QOSF member/supporter today by simply subscriping to our <a href="https://mailchi.mp/762c19baab5a/qosf-supporter">newsletter</a>.
+Membership in the QOSF is open and free to anyone interested in open source software development for quantum computing. Members and supporters of the QOSF are not obliged to donate to the foundation itself but are committing to support the values stated in this manifesto. There are no dues of any kind. You can become a QOSF member/supporter today by simply subscribing to our <a href="https://mailchi.mp/762c19baab5a/qosf-supporter">newsletter</a>.
 
 # Amendments
 Amendments to this manifesto may be proposed by petition supported by at least 10% (at the time of submission) of QOSF members and must be submitted to the board of directors of the QOSF. The proposed amendment shall be submitted to the QOSF members for vote at the time of our biannual meetings. If approved by vote through an absolute majority of the QOSF members, the amendment is approved. An approved amendment shall be effective immediately, unless otherwise specified in the amendment itself.


### PR DESCRIPTION
Typo at '... can become a QOSF member/supporter today by simply _subscriping_ to our...'