### PR TITLE
Automated team.MD, closes #28

### DIFF
--- a/qosf.org/scripts/contributors.py
+++ b/qosf.org/scripts/contributors.py
@@ -1,0 +1,68 @@
+import re
+import requests
+
+# Constants for GitHub API
+GITHUB_API = "https://api.github.com"
+ORGANIZATION = "qosf"
+
+def get_repos(org):
+    """Get the list of repositories for the organization."""
+    url = f"{GITHUB_API}/orgs/{org}/repos"
+    response = requests.get(url)
+    return response.json()  # This will return a list of repositories.
+
+def get_contributors(repo):
+    """Get the list of contributors for a repository."""
+    url = f"{GITHUB_API}/repos/{ORGANIZATION}/{repo}/contributors"
+    response = requests.get(url)
+    return response.json()  # This will return a list of contributors.
+
+def generate_contributor_snippet(contributor):
+    """Generate the HTML snippet for a single contributor."""
+    # You would create the HTML snippet based on the structure in `team.md`
+    return "<li>" + contributor + "</li>"
+
+def update_team_md(snippets):
+    """Update the team.md file with a new list of contributors."""
+    with open("qosf.org/team.md", "r", encoding='utf-8') as file:
+        content = file.read()
+
+    # Define the start and end markers and the regex pattern to find the section
+    start_marker = "<ul>"
+    end_marker = "</ul>"
+    pattern = re.compile(f"({re.escape(start_marker)}).*?({re.escape(end_marker)})", re.DOTALL)
+    # Join all contributors snippets into a single string
+    contributors_section = "\n\t\t".join(snippets)
+    # Replace the section between the markers with the new contributors' section
+    new_content = pattern.sub(rf"\1{contributors_section}\2", content)
+
+    # Write the updated content back to the file
+    with open("qosf.org/team.md", "w", encoding='utf-8') as file:
+        file.write(new_content)
+
+"""def generate_start_section():
+    print("<div class="callout callout--info">
+    <p><strong>A big thank you to all the engaged Github/Gitlab contributors on all of our various repos! You are making QOSF possible!</strong>
+    Become a QOSF contributor by opening an issue or submitting a pull request on our <a href="https://github.com/qosf">GitHub</a> or <a href="https://gitlab.com/qosf">GitLab</a> page.
+    </p></div>")
+
+def generate_end_section():
+    print("")"""
+
+def main():
+    repos = get_repos(ORGANIZATION)
+    all_contributors = {}
+
+    # Collect and sort contributors from all repos
+    for repo in repos:
+        for contributor in get_contributors(repo['name']):
+            all_contributors[contributor['login']] = contributor
+    sorted_contributors = list(dict(sorted(all_contributors.items())).keys())
+
+    # Generate HTML snippets for each contributor
+    snippets = [generate_contributor_snippet(contributor) for contributor in sorted_contributors]
+    # Update team.md
+    update_team_md(snippets)
+
+if __name__ == "__main__":
+    main()

--- a/qosf.org/scripts/contributors.py
+++ b/qosf.org/scripts/contributors.py
@@ -28,6 +28,8 @@ def update_team_md(snippets):
         content = file.read()
 
     # Define the start and end markers and the regex pattern to find the section
+    # Current implementation breaks if we have multiple html unnumbered lists
+    # Easy to fix if needed
     start_marker = "<ul>"
     end_marker = "</ul>"
     pattern = re.compile(f"({re.escape(start_marker)}).*?({re.escape(end_marker)})", re.DOTALL)
@@ -39,15 +41,6 @@ def update_team_md(snippets):
     # Write the updated content back to the file
     with open("qosf.org/team.md", "w", encoding='utf-8') as file:
         file.write(new_content)
-
-"""def generate_start_section():
-    print("<div class="callout callout--info">
-    <p><strong>A big thank you to all the engaged Github/Gitlab contributors on all of our various repos! You are making QOSF possible!</strong>
-    Become a QOSF contributor by opening an issue or submitting a pull request on our <a href="https://github.com/qosf">GitHub</a> or <a href="https://gitlab.com/qosf">GitLab</a> page.
-    </p></div>")
-
-def generate_end_section():
-    print("")"""
 
 def main():
     repos = get_repos(ORGANIZATION)

--- a/qosf.org/team.md
+++ b/qosf.org/team.md
@@ -60,7 +60,6 @@ micro_nav: false
     </div>
     <div class='col-md-8' style='text-align: justify;'>
        <b>Michał Stęchły</b> got into open source thanks to quantum computing - when he discovered he can contribute to the quantum computing community as a newcomer to the field, he immediately fell in love with the idea. He authored and supported open source implementations and research of several quantum computing algorithms. Michał has also a blog <a href="https://www.mustythoughts.com">"Musty Thoughts"</a>, which aims to help people get into the realm of quantum computing. Professionally, he is a Quantum Software Engineer at <a href="https://www.zapatacomputing.com">Zapata Computing</a>.
-
     </div>
 </div>
 
@@ -74,7 +73,6 @@ micro_nav: false
     </div>
     <div class='col-md-8' style='text-align: justify;'>
        <b>Maggie Li</b> loves all things open source, from science to software, as a believer in innovation through collaboration. She stepped into the world of open source software as a quantum computing amateur by contributing to <a href="https://github.com/XanaduAI/pennylane">PennyLane</a>, thanks to QOSF's Quantum Mentorship Program. Outside of quantum computing, she cares about healthcare and education accessibility.
-
     </div>
 </div>
 
@@ -91,6 +89,7 @@ micro_nav: false
         <b>Peter Wittek<sup>&#8224;</sup></b> was a life-long fan of free and open source software who got furious every time he had to fill in a PDF form that did not work on Linux. When he was not preaching about the importance of open source software, he pursued research on the borderline of artificial intelligence and quantum physics as an Assistant Professor in the University of Toronto, and as an affiliate in the Vector Institute for Artificial Intelligence and the Perimeter Institute for Theoretical Physics. He also was the Academic Director of the Quantum Stream in the Creative Destruction Lab, where he saw dozens of startups exploring ideas using quantum computers and the corresponding software stack. In September 2019, he disappeared in an avalanche during a mountaineering expedition on Mt. Trishul in the Himalayas.
     </div>
 </div>
+<br>
 
 # Contributors
 
@@ -98,6 +97,84 @@ micro_nav: false
     <p><strong>A big thank you to all the engaged Github/Gitlab contributors on all of our various repos! You are making QOSF possible!</strong>
     Become a QOSF contributor by opening an issue or submitting a pull request on our <a href="https://github.com/qosf">GitHub</a> or <a href="https://gitlab.com/qosf">GitLab</a> page.
     </p>
+	<p> Contributor list:
+	<ul><li>00mjk</li>
+		<li>1ucian0</li>
+		<li>BillyLjm</li>
+		<li>InfamousPlatypus</li>
+		<li>JoelPasvolsky</li>
+		<li>MaldoAlberto</li>
+		<li>MariaBat</li>
+		<li>MarkCunningham0410</li>
+		<li>Qottmann</li>
+		<li>Qubit1718</li>
+		<li>Roger-luo</li>
+		<li>SSdevelop</li>
+		<li>Shiro-Raven</li>
+		<li>Sinestro38</li>
+		<li>TerraVenil</li>
+		<li>TheGupta2012</li>
+		<li>Travis-S-IBM</li>
+		<li>VoicuTomut</li>
+		<li>aditya-giri</li>
+		<li>amirebrahimi</li>
+		<li>artix41</li>
+		<li>bestquark</li>
+		<li>boegel</li>
+		<li>contepablod</li>
+		<li>crazy4pi314</li>
+		<li>dangirsh</li>
+		<li>dependabot[bot]</li>
+		<li>desireevl</li>
+		<li>dhruvbhq</li>
+		<li>diemilio</li>
+		<li>dlyongemallo</li>
+		<li>dstrain115</li>
+		<li>dudalev</li>
+		<li>efratshabtai</li>
+		<li>enakai00</li>
+		<li>georgios-ts</li>
+		<li>giorgosgiapis</li>
+		<li>hay-k</li>
+		<li>hillmich</li>
+		<li>iamvamsikrishnad</li>
+		<li>ihincks</li>
+		<li>johnzl-777</li>
+		<li>josh146</li>
+		<li>kodaj</li>
+		<li>ksjin-git</li>
+		<li>lazyoracle</li>
+		<li>lkuligin</li>
+		<li>lvignoli</li>
+		<li>lzylili</li>
+		<li>mariaschuld</li>
+		<li>markf94</li>
+		<li>miguefalvarez</li>
+		<li>mkalis</li>
+		<li>mstechly</li>
+		<li>oscarhiggott</li>
+		<li>peguerosdc</li>
+		<li>peterwittek</li>
+		<li>prince-ph0en1x</li>
+		<li>rryoung98</li>
+		<li>rsln-s</li>
+		<li>saravsak</li>
+		<li>scarrazza</li>
+		<li>sikfeng</li>
+		<li>silky</li>
+		<li>spakin</li>
+		<li>stared</li>
+		<li>stewdio</li>
+		<li>tbabej</li>
+		<li>tjstavenger-pnnl</li>
+		<li>tlubowe</li>
+		<li>vic023</li>
+		<li>vprusso</li>
+		<li>vsoftco</li>
+		<li>willzeng</li>
+		<li>yardolabs</li>
+		<li>yourball</li></ul>
+	</p>
 </div>
 
 # Donors


### PR DESCRIPTION
I have written a python file that can automatically update team.MD.

Also minor changes to team.MD.

If need be, I can:
- Change the text before the contributor list
- Change the sorting and display (currently, Uppercase comes first, so it is -> 1b, Ab, aa. I can change it so that it is -> 1b, aa, Ab, OR 1b, aa, ab.
- Make this automatic using github actions (not 100% sure about this)
- Current implementation only allows for only one <ul> </ul>. It can be easily improved but I have left it for readability.
- Add type annotations (I think I have sufficient docstrings and comments)
- PEP8 or any standard that you'd like

Let me know if this works, because this should close #28 