### PR TITLE
Apply existing manifesto page styling

### DIFF
--- a/qosf.org/manifesto.md
+++ b/qosf.org/manifesto.md
@@ -3,13 +3,15 @@
 # Page settings
 layout: default
 keywords:
+left_illustration: illustrations/manifesto_left_side.png
+right_illustration: illustrations/manifesto_right_side.png
+custom_css: manifesto.css
 comments: false
 
 # Hero section
 title: QOSF Manifesto
 description: Our core beliefs and mission statement, and why you should get excited about us.
 buttons:
-      icon: home
     - icon: slack
       content: Join our Slack
       url: 'https://join.slack.com/t/qosf/shared_invite/zt-2nq2n0t9i-PyiiCKg1bAzRpNzLMM7pWg'


### PR DESCRIPTION
## Summary

Fixes #136.

This PR connects the manifesto page to the existing manifesto-specific styling and illustration assets already present in the site.

## Problem

The manifesto page front matter did not load the existing manifesto CSS or side illustrations. It also had a stray button entry that made the page metadata inconsistent with the intended Slack call-to-action.

## Change

- Add the existing left and right manifesto illustrations to the page front matter.
- Load the existing `manifesto.css` stylesheet for this page.
- Keep the Slack button as the only button entry.

## Tests

- `git diff --check HEAD~1..HEAD`
- Ruby front-matter and asset-reference checks for `manifesto.css`, `manifesto_left_side.png`, and `manifesto_right_side.png`
- Dockerized Ruby 3.2 frozen-lockfile `bundle install` plus `jekyll build` passed during QA.

## Risk

Low. The change is limited to `qosf.org/manifesto.md` front matter and reuses assets already in the repository.

## Notes

Native macOS `bundle install` was not used because the local system Ruby environment lacks usable build headers. The Dockerized Ruby 3.2 build passed.
